### PR TITLE
Pass info about gift

### DIFF
--- a/mailalerts.php
+++ b/mailalerts.php
@@ -377,6 +377,8 @@ class MailAlerts extends Module
 				),
 			'{total_wrapping}' => Tools::displayPrice($order->total_wrapping, $currency),
 			'{currency}' => $currency->sign,
+			'{gift}' => $order->gift ? 'Yes' : 'No',
+			'{gift_message}' => $order->gift_message,
 			'{message}' => $message
 		);
 


### PR DESCRIPTION
The gift state and message should be passed to the mail alerts, this can be done by adding

'{gift}' => $order->gift ? 'Yes' : 'No',
'{gift_message}' => $order->gift_message,

in the &template_vars declaration, starting on line 323, i added those at the just, just before {message}.

Regards,
Christophe