### PR TITLE
[*] MO : mailalerts - Include the Order Status in the New Order email

### DIFF
--- a/mailalerts.php
+++ b/mailalerts.php
@@ -323,6 +323,8 @@ class MailAlerts extends Module
 			$total_products = $order->getTotalProductsWithoutTaxes();
 		else
 			$total_products = $order->getTotalProductsWithTaxes();
+		
+		$order_state = $params['orderStatus'];
 
 		// Filling-in vars for email
 		$template_vars = array(
@@ -366,6 +368,7 @@ class MailAlerts extends Module
 			'{invoice_phone}' => $invoice->phone ? $invoice->phone : $invoice->phone_mobile,
 			'{invoice_other}' => $invoice->other,
 			'{order_name}' => $order->reference,
+			'{order_status}' => $order_state->name,
 			'{shop_name}' => $configuration['PS_SHOP_NAME'],
 			'{date}' => $order_date_text,
 			'{carrier}' => (($carrier->name == '0') ? $configuration['PS_SHOP_NAME'] : $carrier->name),

--- a/mails/en/new_order.html
+++ b/mails/en/new_order.html
@@ -95,7 +95,8 @@
 			Order details		</p>
 		<span style="color:#777">
 			<span style="color:#333"><strong>Order:</strong></span> {order_name} Placed on {date}<br /><br />
-			<span style="color:#333"><strong>Payment:</strong></span> {payment}
+			<span style="color:#333"><strong>Payment:</strong></span> {payment}<br /><br />
+			<span style="color:#333"><strong>Order Status:</strong></span> {order_status}
 		</span>
 	</td>
 </tr>

--- a/mails/en/new_order.txt
+++ b/mails/en/new_order.txt
@@ -12,6 +12,8 @@ ORDER: {order_name} Placed on {date}
 
 PAYMENT: {payment} 
 
+ORDER STATUS: {order_status}
+
 REFERENCE
 
 PRODUCT


### PR DESCRIPTION
Something came up at work... an order was validated with status "payment failed" by a payment module, they still got the new_order email which confused the client.
This might require some input from others, but this PR adds the order state into the email so hopefully, will lead to less confusion.