### PR TITLE
[-] MO : mailalerts - Fixed bug when Customer is logged as a Guest

### DIFF
--- a/mailalerts.php
+++ b/mailalerts.php
@@ -470,7 +470,7 @@ class MailAlerts extends Module
 		$id_product_attribute = 0;
 		$id_customer = (int)$context->customer->id;
 
-		if ((int)$context->customer->id <= 0)
+		if ((int)!$context->customer->isLogged())
 			$this->context->smarty->assign('email', 1);
 		elseif (MailAlert::customerHasNotification($id_customer, $id_product, $id_product_attribute, (int)$context->shop->id))
 			return;


### PR DESCRIPTION
When customer is logged as a Guest he can't get notification (can't enter his e-mail in mailalerts e-mail block)