### PR TITLE
colored the order status to HTML email

### DIFF
--- a/mailalerts.php
+++ b/mailalerts.php
@@ -382,6 +382,7 @@ class MailAlerts extends Module
 			'{invoice_phone}' => $invoice->phone ? $invoice->phone : $invoice->phone_mobile,
 			'{invoice_other}' => $invoice->other,
 			'{order_name}' => $order->reference,
+			'{order_status_color}' => $order_state->color,
 			'{order_status}' => $order_state->name,
 			'{shop_name}' => $configuration['PS_SHOP_NAME'],
 			'{date}' => $order_date_text,


### PR DESCRIPTION
needs a patched template, eg:
index 2f3107d..05248bb 100644
--- a/mails/fr/new_order.html
+++ b/mails/fr/new_order.html
@@ -96,11 +96,11 @@
 				<td style="padding:7px 0">
 					<font size="2" face="Open-sans, sans-serif" color="#555454">
 						<p data-html-only="1" style="border-bottom:1px solid #D6D4D4;margin:3px 0 7px;text-transform:uppercase;font-weight:500;font-size:18px;padding-bottom:10px">
-							Détails de la commande						</p>
+							Détails de la commande</p>
 						<span style="color:#777">
-							<span style="color:#333"><strong>Commande :</strong></span> {order_name} Date {date}<br /><br />
-							<span style="color:#333"><strong>Paiement :</strong></span> {payment}
-							<span style="color:#333"><strong>Statut :</strong></span> {order_status}
+							<span style="color:#333"><strong>Commande :</strong></span> {order_name} Date {date}<br />
+							<span style="color:#333"><strong>Paiement :</strong></span> {payment}<br/>
+							<span style="color:{order_status_color}"><strong style="color:#333">Statut :</strong> {order_status}</span>
 						</span>
 					</font>
 				</td>