### PR TITLE
When out of stock, Email should be required when customer not logged in

### DIFF
--- a/mailalerts.php
+++ b/mailalerts.php
@@ -470,7 +470,7 @@ class MailAlerts extends Module
 		$id_product_attribute = 0;
 		$id_customer = (int)$context->customer->id;
 
-		if ((int)$context->customer->id <= 0)
+		if (!$context->customer->isLogged())
 			$this->context->smarty->assign('email', 1);
 		elseif (MailAlert::customerHasNotification($id_customer, $id_product, $id_product_attribute, (int)$context->shop->id))
 			return;


### PR DESCRIPTION
Make the consistent check whether the email addres should be possible to provide by user - the actions.php controller checks if customer is logged in to decide wheter to take email from parameter or from customer context. This change prevents the scenario whit missing email information when customer has the account but is not logged in when making the request.