### PR TITLE
FO: Added validation check on email

### DIFF
--- a/controllers/front/actions.php
+++ b/controllers/front/actions.php
@@ -96,6 +96,10 @@ class MailalertsActionsModuleFrontController extends ModuleFrontController
 			$customer = $context->customer->getByEmail($customer_email);
 			$id_customer = (isset($customer->id) && ($customer->id != null)) ? (int)$customer->id : null;
 		}
+        
+        if (!filter_var($customer_email, FILTER_VALIDATE_EMAIL)) {
+            die('0');
+        }
 
 		$id_product = (int)Tools::getValue('id_product');
 		$id_product_attribute = (int)Tools::getValue('id_product_attribute');


### PR DESCRIPTION
There is issues where an invalid email address will cause the stock updates to fail. 
This will prevent invalid email addresses to be saved to the database.